### PR TITLE
Move scale bar because it is hidden by map sources

### DIFF
--- a/ShinyModule.R
+++ b/ShinyModule.R
@@ -342,7 +342,7 @@ shinyModule <- function(input, output, session, data){
       addCircleMarkers(data = tail(coordinates(data_sel_id()),n=3), fillOpacity = 0.3, opacity = 0.5, color="red", radius=1, group = "last positions") %>%
       addLegend(position= "topright", colors=c("cyan","blue","red"),
                 labels=c("lines","points","last positions") ,opacity = 0.7, title = paste("track",unique(trackId(data_sel_id())))) %>%
-      addScaleBar(position="bottomleft",
+      addScaleBar(position="topleft",
                   options=scaleBarOptions(maxWidth = 100,
                                           metric = TRUE, imperial = F, updateWhenIdle = TRUE)) %>%
       addLayersControl(


### PR DESCRIPTION
Hi @andreakoelzsch,
As discussed earlier, here's a PR to move the scale bar to the top left of the map because it is hidden by the map sources in the bottom left.
Best,
Alex